### PR TITLE
Missing kms action

### DIFF
--- a/kms.tf
+++ b/kms.tf
@@ -66,7 +66,8 @@ data "aws_iam_policy_document" "kms_source_policy" {
       "kms:Decrypt",
       "kms:ReEncrypt*",
       "kms:GenerateDataKey*",
-      "kms:DescribeKey"
+      "kms:DescribeKey",
+      "kms:CreateGrant"
     ]
 
     #checkov:skip=CKV_AWS_109
@@ -109,7 +110,8 @@ data "aws_iam_policy_document" "kms_target_policy" {
       "kms:Decrypt",
       "kms:ReEncrypt*",
       "kms:GenerateDataKey*",
-      "kms:DescribeKey"
+      "kms:DescribeKey",
+      "kms:CreateGrant"
     ]
 
     #checkov:skip=CKV_AWS_109


### PR DESCRIPTION
# Description
Added kms action `kms:CreateGrant` to kms policy. Without this action, the copy job of aurora cluster between accounts was failing 

## Type of change

- [x] A bug fix (PR prefix `fix`)
- [ ] A new feature (PR prefix `feat`)
- [ ] A code change that neither fixes a bug nor adds a feature (PR prefix `refactor`)
- [ ] Adding missing tests or correcting existing tests (PR prefix `test`)
- [ ] Changes that do not affect the meaning of the code like white-spaces, formatting, missing semi-colons, etc. (PR prefix `style`)
- [ ] Changes to our CI configuration files and scripts (PR prefix `ci`)
- [ ] Documentation only changes (PR prefix `docs`)

## How Has This Been Tested?
Tested by running copy job between accounts.

