### PR TITLE
fix(backup-selection): remove resources selector from tag selection

### DIFF
--- a/aws_backup.tf
+++ b/aws_backup.tf
@@ -104,7 +104,6 @@ resource "aws_backup_selection" "tag" {
   iam_role_arn = module.source_role.arn
   plan_id      = aws_backup_plan.source[each.value.backup_plan_key].id
   name         = substr("${module.source_label.id}-${each.key}", 0, 50)
-  resources    = ["*"]
   selection_tag {
     type  = each.value.selection_tag["type"]
     key   = each.value.selection_tag["key"]


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change, provide a justification and which issue is fixed.
-->

- When specifying backup selection using just tags, resource selector must not be used as AWS calculates target resources on "OR" fashion.

## Type of change

- [x] A bug fix (PR prefix `fix`)
- [ ] A new feature (PR prefix `feat`)
- [ ] A code change that neither fixes a bug nor adds a feature (PR prefix `refactor`)
- [ ] Adding missing tests or correcting existing tests (PR prefix `test`)
- [ ] Changes that do not affect the meaning of the code like white-spaces, formatting, missing semi-colons, etc. (PR prefix `style`)
- [ ] Changes to our CI configuration files and scripts (PR prefix `ci`)
- [ ] Documentation only changes (PR prefix `docs`)

## How Has This Been Tested?

<!--
Please describe the tests that you ran to verify your changes.
-->

- Create AWS Backup plan with selection using tags, when `resources = [*]` is present, all resources supported by AWS Backup service are backed up.
